### PR TITLE
Fix Permissions.lua

### DIFF
--- a/permissions.lua
+++ b/permissions.lua
@@ -14,6 +14,9 @@ function permissions_init()
 	default.set_allows_action(defines.input_action.set_train_stopped, false)
 	default.set_allows_action(defines.input_action.change_train_stop_station, false)
 	game.permissions.create_group("trusted") --For level 5+ players.
+	
+	global.patreon.patreons = {}
+	global.trusted.list = {}
 end
 
 function permissions_upgrade(event)
@@ -32,11 +35,8 @@ function permissions_precheck(event)
 	local player = game.players[player_index]
 	if patreon_check(player) or player.admin then
 		p.permission_group = game.permissions.get_group("trusted")
-
+	end
 end
-
-global.patreon.patreons
-global.trusted.list
 
 Event.register()
 Event.register(defines.events.on_player_created, permissions_precheck)


### PR DESCRIPTION
As it was, permissions.lua would not launch. Globals set in the root code (outside of any function or an on_init) are overwriten when the game starts (See http://lua-api.factorio.com/latest/Data-Lifecycle.html), and the fact they weren't even being set to a blank table made it a Lua syntax error.
An `end` was also missing from permissions_precheck