### PR TITLE
Fixed typo

### DIFF
--- a/lualib/antigrief.lua
+++ b/lualib/antigrief.lua
@@ -33,7 +33,7 @@ end
 function antigrief.banhammer(player)
     --If player is > level 5, then warn first.
     --What permission group is the player in?
-    if player.permissions_group.name == "trusted" then --Kick first.
+    if player.permission_group.name == "trusted" then --Kick first.
         if not global.antigrief.warned[player.name] then
             global.antigrief.warned[player.name] = true
             game.kick_player(player, "griefing (automoderator)")


### PR DESCRIPTION
Changed "permissions_group" to "permission_group" so arty misuse properly bans players as intended.