### PR TITLE
Added player-count compensation

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -22,7 +22,7 @@ require "equipment"
 require "lualib/pdnc" --Zr's fancy day-night cycle stuff
 
 -- doomsday is ready for use! Defaults to about 5h until doomsday. 
--- require "lualib/doomsday" -- enables the doomsday module. Default to start doomsday after 3h
+require "lualib/doomsday" -- enables the doomsday module. Default to start doomsday after 3h
 
 -- MAP GENERATORS
 -- require "maps/grid"


### PR DESCRIPTION
This makes the players run faster if there's fewer players online, and slower if there's many players online, but never slower than default. It does so smoothly, with the change being a linear at a speed of 1 player change every 17.5 sec.